### PR TITLE
feat(indexer): add workspace management for multi-repo grouping

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -62,14 +62,20 @@ pub async fn search(
 
     // Resolve workspace to index names if specified
     let search_indexes = if let Some(ws_name) = workspace {
-        let ws_indexes = indexer.get_workspace_index_names(ws_name).await
-            .ok_or_else(|| crate::Error::InvalidArgument(format!("Workspace not found: {}", ws_name)))?;
+        let ws_indexes = indexer
+            .get_workspace_index_names(ws_name)
+            .await
+            .ok_or_else(|| {
+                crate::Error::InvalidArgument(format!("Workspace not found: {}", ws_name))
+            })?;
         Some(ws_indexes)
     } else {
         indexes
     };
 
-    let results = indexer.search(query, search_indexes.as_deref(), top_k).await?;
+    let results = indexer
+        .search(query, search_indexes.as_deref(), top_k)
+        .await?;
 
     if results.is_empty() {
         output::warning(&format!("No results found for: {}", query));
@@ -448,7 +454,10 @@ pub async fn workspace_add_repo(
     repo_url: &str,
     token: Option<&str>,
 ) -> Result<()> {
-    let spinner = output::spinner(&format!("Adding repository to workspace: {}", workspace_name));
+    let spinner = output::spinner(&format!(
+        "Adding repository to workspace: {}",
+        workspace_name
+    ));
 
     let (provider_type, owner, repo_name, base_url) = parse_repo_url(repo_url)?;
     let provider_type_str = format!("{:?}", provider_type).to_lowercase();
@@ -459,7 +468,10 @@ pub async fn workspace_add_repo(
     indexer.add_repo_to_workspace(workspace_name, &repo).await?;
     spinner.finish_and_clear();
 
-    output::success(&format!("Added {} to workspace: {}", repo.full_name, workspace_name));
+    output::success(&format!(
+        "Added {} to workspace: {}",
+        repo.full_name, workspace_name
+    ));
 
     Ok(())
 }
@@ -470,13 +482,21 @@ pub async fn workspace_remove_repo(
     workspace_name: &str,
     repo_id: &str,
 ) -> Result<()> {
-    let spinner = output::spinner(&format!("Removing repository from workspace: {}", workspace_name));
+    let spinner = output::spinner(&format!(
+        "Removing repository from workspace: {}",
+        workspace_name
+    ));
 
     let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
-    indexer.remove_repo_from_workspace(workspace_name, repo_id).await?;
+    indexer
+        .remove_repo_from_workspace(workspace_name, repo_id)
+        .await?;
     spinner.finish_and_clear();
 
-    output::success(&format!("Removed {} from workspace: {}", repo_id, workspace_name));
+    output::success(&format!(
+        "Removed {} from workspace: {}",
+        repo_id, workspace_name
+    ));
 
     Ok(())
 }
@@ -567,7 +587,14 @@ mod tests {
     async fn test_search_with_special_chars_query() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "fn main() { println!(\"hello\"); }", None, None, 10).await;
+        let result = search(
+            &config,
+            "fn main() { println!(\"hello\"); }",
+            None,
+            None,
+            10,
+        )
+        .await;
         assert!(result.is_ok());
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -55,11 +55,21 @@ pub async fn search(
     config: &Config,
     query: &str,
     indexes: Option<Vec<String>>,
+    workspace: Option<&str>,
     top_k: usize,
 ) -> Result<()> {
     let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
 
-    let results = indexer.search(query, indexes.as_deref(), top_k).await?;
+    // Resolve workspace to index names if specified
+    let search_indexes = if let Some(ws_name) = workspace {
+        let ws_indexes = indexer.get_workspace_index_names(ws_name).await
+            .ok_or_else(|| crate::Error::InvalidArgument(format!("Workspace not found: {}", ws_name)))?;
+        Some(ws_indexes)
+    } else {
+        indexes
+    };
+
+    let results = indexer.search(query, search_indexes.as_deref(), top_k).await?;
 
     if results.is_empty() {
         output::warning(&format!("No results found for: {}", query));
@@ -342,6 +352,135 @@ pub async fn config_init(output_path: Option<std::path::PathBuf>) -> Result<()> 
     Ok(())
 }
 
+/// Create a new workspace with one or more repositories
+pub async fn workspace_create(
+    config: &Config,
+    name: &str,
+    repo_urls: &[String],
+    token: Option<&str>,
+) -> Result<()> {
+    let spinner = output::spinner(&format!("Creating workspace: {}", name));
+
+    let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
+
+    let mut repos = Vec::new();
+    for url in repo_urls {
+        let (provider_type, owner, repo_name, base_url) = parse_repo_url(url)?;
+        let provider_type_str = format!("{:?}", provider_type).to_lowercase();
+        let provider = create_provider(&provider_type_str, base_url.as_deref(), token, None)?;
+        let repo = provider.get_repository(&owner, &repo_name).await?;
+        repos.push(repo);
+    }
+
+    let workspace = indexer.create_workspace(name, &repos).await?;
+    spinner.finish_and_clear();
+
+    output::success(&format!("Created workspace: {}", name));
+    println!("  Repositories: {}", workspace.repositories.len());
+    for repo in &workspace.repositories {
+        println!("    - {}", repo.full_name);
+    }
+
+    Ok(())
+}
+
+/// List all workspaces
+pub async fn workspace_list(config: &Config) -> Result<()> {
+    let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
+    let workspaces = indexer.list_workspaces().await;
+
+    if workspaces.is_empty() {
+        output::warning("No workspaces found. Use 'islands workspace create' to create one.");
+        return Ok(());
+    }
+
+    println!("\nIslands Workspaces\n");
+
+    for ws in workspaces {
+        println!(
+            "{} ({} repositories)",
+            console::style(&ws.name).cyan().bold(),
+            ws.repositories.len()
+        );
+        for repo in &ws.repositories {
+            println!("    - {}", repo.full_name);
+        }
+        println!("  Created: {}", ws.created_at);
+        println!("  Updated: {}", ws.updated_at);
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Delete a workspace
+pub async fn workspace_delete(config: &Config, name: &str, force: bool) -> Result<()> {
+    let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
+
+    if !force {
+        output::warning(&format!("This will delete workspace '{}'.", name));
+        print!("Are you sure? (y/N): ");
+        std::io::Write::flush(&mut std::io::stdout())?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        if input != "y" && input != "yes" {
+            output::info("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let spinner = output::spinner(&format!("Deleting workspace: {}", name));
+    indexer.delete_workspace(name).await?;
+    spinner.finish_and_clear();
+
+    output::success(&format!("Deleted workspace: {}", name));
+
+    Ok(())
+}
+
+/// Add a repository to an existing workspace
+pub async fn workspace_add_repo(
+    config: &Config,
+    workspace_name: &str,
+    repo_url: &str,
+    token: Option<&str>,
+) -> Result<()> {
+    let spinner = output::spinner(&format!("Adding repository to workspace: {}", workspace_name));
+
+    let (provider_type, owner, repo_name, base_url) = parse_repo_url(repo_url)?;
+    let provider_type_str = format!("{:?}", provider_type).to_lowercase();
+    let provider = create_provider(&provider_type_str, base_url.as_deref(), token, None)?;
+    let repo = provider.get_repository(&owner, &repo_name).await?;
+
+    let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
+    indexer.add_repo_to_workspace(workspace_name, &repo).await?;
+    spinner.finish_and_clear();
+
+    output::success(&format!("Added {} to workspace: {}", repo.full_name, workspace_name));
+
+    Ok(())
+}
+
+/// Remove a repository from a workspace
+pub async fn workspace_remove_repo(
+    config: &Config,
+    workspace_name: &str,
+    repo_id: &str,
+) -> Result<()> {
+    let spinner = output::spinner(&format!("Removing repository from workspace: {}", workspace_name));
+
+    let indexer = IndexerService::new(config.indexer.clone(), HashMap::new());
+    indexer.remove_repo_from_workspace(workspace_name, repo_id).await?;
+    spinner.finish_and_clear();
+
+    output::success(&format!("Removed {} from workspace: {}", repo_id, workspace_name));
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,7 +518,7 @@ mod tests {
         let (config, _dir) = test_config();
 
         // Searching with no indexes should return Ok (with warning printed)
-        let result = search(&config, "test query", None, 10).await;
+        let result = search(&config, "test query", None, None, 10).await;
         assert!(result.is_ok());
     }
 
@@ -387,7 +526,7 @@ mod tests {
     async fn test_search_with_empty_query_returns_ok() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "", None, 10).await;
+        let result = search(&config, "", None, None, 10).await;
         assert!(result.is_ok());
     }
 
@@ -396,7 +535,7 @@ mod tests {
         let (config, _dir) = test_config();
 
         let indexes = vec!["nonexistent/repo".to_string()];
-        let result = search(&config, "query", Some(indexes), 5).await;
+        let result = search(&config, "query", Some(indexes), None, 5).await;
         assert!(result.is_ok());
     }
 
@@ -404,7 +543,7 @@ mod tests {
     async fn test_search_with_top_k_zero() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "test", None, 0).await;
+        let result = search(&config, "test", None, None, 0).await;
         assert!(result.is_ok());
     }
 
@@ -412,7 +551,7 @@ mod tests {
     async fn test_search_with_large_top_k() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "test", None, 10000).await;
+        let result = search(&config, "test", None, None, 10000).await;
         assert!(result.is_ok());
     }
 
@@ -420,7 +559,7 @@ mod tests {
     async fn test_search_with_unicode_query() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "unicode test", None, 10).await;
+        let result = search(&config, "unicode test", None, None, 10).await;
         assert!(result.is_ok());
     }
 
@@ -428,7 +567,7 @@ mod tests {
     async fn test_search_with_special_chars_query() {
         let (config, _dir) = test_config();
 
-        let result = search(&config, "fn main() { println!(\"hello\"); }", None, 10).await;
+        let result = search(&config, "fn main() { println!(\"hello\"); }", None, None, 10).await;
         assert!(result.is_ok());
     }
 
@@ -755,7 +894,7 @@ mod tests {
         // Multiple operations should work with same config
         let _ = show_status(&config).await;
         let _ = list_indexes(&config).await;
-        let _ = search(&config, "test", None, 10).await;
+        let _ = search(&config, "test", None, None, 10).await;
 
         // All should complete without panicking
     }
@@ -776,7 +915,7 @@ mod tests {
         let (config, _dir) = test_config();
 
         let empty_indexes: Vec<String> = vec![];
-        let result = search(&config, "query", Some(empty_indexes), 10).await;
+        let result = search(&config, "query", Some(empty_indexes), None, 10).await;
         assert!(result.is_ok());
     }
 
@@ -855,9 +994,9 @@ mod tests {
         let config3 = config.clone();
 
         let (r1, r2, r3) = tokio::join!(
-            search(&config1, "query1", None, 5),
-            search(&config2, "query2", None, 5),
-            search(&config3, "query3", None, 5),
+            search(&config1, "query1", None, None, 5),
+            search(&config2, "query2", None, None, 5),
+            search(&config3, "query3", None, None, 5),
         );
 
         assert!(r1.is_ok());
@@ -893,7 +1032,7 @@ mod tests {
         assert!(list_indexes(&config).await.is_ok());
 
         // Search (empty)
-        assert!(search(&config, "test", None, 10).await.is_ok());
+        assert!(search(&config, "test", None, None, 10).await.is_ok());
 
         // Sync non-existent (error)
         assert!(sync_repository(&config, "nonexistent").await.is_err());

--- a/src/indexer/error.rs
+++ b/src/indexer/error.rs
@@ -28,6 +28,14 @@ pub enum Error {
     #[error("index not found: {0}")]
     IndexNotFound(String),
 
+    /// Workspace not found
+    #[error("workspace not found: {0}")]
+    WorkspaceNotFound(String),
+
+    /// Repository not in workspace
+    #[error("repository not in workspace: {0}")]
+    RepositoryNotInWorkspace(String),
+
     /// Indexing failed
     #[error("indexing failed: {0}")]
     IndexingFailed(String),
@@ -68,6 +76,18 @@ impl Error {
     #[must_use]
     pub fn index_not_found(name: impl Into<String>) -> Self {
         Self::IndexNotFound(name.into())
+    }
+
+    /// Create a workspace not found error
+    #[must_use]
+    pub fn workspace_not_found(name: impl Into<String>) -> Self {
+        Self::WorkspaceNotFound(name.into())
+    }
+
+    /// Create a repository not in workspace error
+    #[must_use]
+    pub fn repo_not_in_workspace(name: impl Into<String>) -> Self {
+        Self::RepositoryNotInWorkspace(name.into())
     }
 }
 

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -20,13 +20,15 @@ pub mod watcher;
 
 pub use error::{Error, Result};
 pub use manager::RepositoryManager;
-pub use service::{IndexInfo, IndexerConfig, IndexerService, StoredIndex};
+pub use service::{IndexInfo, IndexerConfig, IndexerService, StoredIndex, WorkspaceInfo};
 pub use state::RepositoryState;
 
 /// Re-export commonly used types
 pub mod prelude {
     pub use super::error::{Error, Result};
     pub use super::manager::RepositoryManager;
-    pub use super::service::{IndexInfo, IndexerConfig, IndexerService, StoredIndex};
+    pub use super::service::{
+        IndexInfo, IndexerConfig, IndexerService, StoredIndex, WorkspaceInfo,
+    };
     pub use super::state::RepositoryState;
 }

--- a/src/indexer/service.rs
+++ b/src/indexer/service.rs
@@ -977,11 +977,7 @@ impl IndexerService {
             .map_err(|e| Error::IndexingFailed(format!("Failed to serialize workspace: {}", e)))?;
         std::fs::write(&workspace.path, &json)?;
 
-        info!(
-            "Added repository '{}' to workspace '{}'",
-            repo.id(),
-            name
-        );
+        info!("Added repository '{}' to workspace '{}'", repo.id(), name);
         Ok(())
     }
 
@@ -1006,11 +1002,7 @@ impl IndexerService {
             .map_err(|e| Error::IndexingFailed(format!("Failed to serialize workspace: {}", e)))?;
         std::fs::write(&workspace.path, &json)?;
 
-        info!(
-            "Removed repository '{}' from workspace '{}'",
-            repo_id,
-            name
-        );
+        info!("Removed repository '{}' from workspace '{}'", repo_id, name);
         Ok(())
     }
 
@@ -2459,7 +2451,10 @@ mod tests {
             "frontend",
             "https://github.com/org/frontend.git",
         );
-        service.create_workspace("my-project", &[repo1]).await.unwrap();
+        service
+            .create_workspace("my-project", &[repo1])
+            .await
+            .unwrap();
 
         // Add another repo to the workspace
         let repo2 = crate::providers::Repository::new(
@@ -2468,14 +2463,21 @@ mod tests {
             "backend",
             "https://github.com/org/backend.git",
         );
-        service.add_repo_to_workspace("my-project", &repo2).await.unwrap();
+        service
+            .add_repo_to_workspace("my-project", &repo2)
+            .await
+            .unwrap();
 
         // Verify workspace now has 2 repos
         let workspaces = service.list_workspaces().await;
         assert_eq!(workspaces.len(), 1);
         assert_eq!(workspaces[0].repositories.len(), 2);
 
-        let repo_names: Vec<_> = workspaces[0].repositories.iter().map(|r| r.name.as_str()).collect();
+        let repo_names: Vec<_> = workspaces[0]
+            .repositories
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect();
         assert!(repo_names.contains(&"frontend"));
         assert!(repo_names.contains(&"backend"));
     }
@@ -2507,14 +2509,21 @@ mod tests {
                 "repo2",
                 "https://github.com/org/repo2.git",
             );
-            service.add_repo_to_workspace("test-ws", &repo2).await.unwrap();
+            service
+                .add_repo_to_workspace("test-ws", &repo2)
+                .await
+                .unwrap();
         }
 
         // New service should see the added repo
         let service2 = IndexerService::new(config, HashMap::new());
         let workspaces = service2.list_workspaces().await;
 
-        assert_eq!(workspaces[0].repositories.len(), 2, "Added repo should persist");
+        assert_eq!(
+            workspaces[0].repositories.len(),
+            2,
+            "Added repo should persist"
+        );
     }
 
     #[tokio::test]
@@ -2565,10 +2574,16 @@ mod tests {
                 "https://github.com/org/backend.git",
             ),
         ];
-        service.create_workspace("my-project", &repos).await.unwrap();
+        service
+            .create_workspace("my-project", &repos)
+            .await
+            .unwrap();
 
         // Remove one repo (repo.id() returns owner/name format)
-        service.remove_repo_from_workspace("my-project", "org/backend").await.unwrap();
+        service
+            .remove_repo_from_workspace("my-project", "org/backend")
+            .await
+            .unwrap();
 
         // Verify workspace now has 1 repo
         let workspaces = service.list_workspaces().await;
@@ -2604,14 +2619,21 @@ mod tests {
                 ),
             ];
             service.create_workspace("test-ws", &repos).await.unwrap();
-            service.remove_repo_from_workspace("test-ws", "org/repo2").await.unwrap();
+            service
+                .remove_repo_from_workspace("test-ws", "org/repo2")
+                .await
+                .unwrap();
         }
 
         // New service should see the removal
         let service2 = IndexerService::new(config, HashMap::new());
         let workspaces = service2.list_workspaces().await;
 
-        assert_eq!(workspaces[0].repositories.len(), 1, "Removal should persist");
+        assert_eq!(
+            workspaces[0].repositories.len(),
+            1,
+            "Removal should persist"
+        );
         assert_eq!(workspaces[0].repositories[0].name, "repo1");
     }
 
@@ -2634,7 +2656,9 @@ mod tests {
         );
         service.create_workspace("test-ws", &[repo]).await.unwrap();
 
-        let result = service.remove_repo_from_workspace("test-ws", "org/nonexistent").await;
+        let result = service
+            .remove_repo_from_workspace("test-ws", "org/nonexistent")
+            .await;
         assert!(result.is_err(), "Should fail for nonexistent repo");
     }
 
@@ -2656,7 +2680,10 @@ mod tests {
             "repo",
             "https://github.com/org/repo.git",
         );
-        service.create_workspace("to-delete", &[repo]).await.unwrap();
+        service
+            .create_workspace("to-delete", &[repo])
+            .await
+            .unwrap();
 
         // Verify it exists
         assert_eq!(service.list_workspaces().await.len(), 1);
@@ -2728,7 +2755,10 @@ mod tests {
                 "https://github.com/org/backend.git",
             ),
         ];
-        service.create_workspace("my-project", &repos).await.unwrap();
+        service
+            .create_workspace("my-project", &repos)
+            .await
+            .unwrap();
 
         // Get index names for workspace
         let names = service.get_workspace_index_names("my-project").await;

--- a/src/indexer/service.rs
+++ b/src/indexer/service.rs
@@ -1,7 +1,7 @@
 //! Main indexer service
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -37,6 +37,21 @@ pub struct IndexInfo {
     pub file_count: usize,
     /// Index size in bytes
     pub size_bytes: u64,
+}
+
+/// Information about a workspace (multi-repo index)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceInfo {
+    /// Workspace name
+    pub name: String,
+    /// Path to workspace metadata
+    pub path: PathBuf,
+    /// Source repositories in this workspace
+    pub repositories: Vec<Repository>,
+    /// When the workspace was created
+    pub created_at: DateTime<Utc>,
+    /// When the workspace was last updated
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Configuration for the indexer service
@@ -210,6 +225,8 @@ pub struct IndexerService {
     indexes: RwLock<HashMap<String, IndexInfo>>,
     /// Stored HNSW graphs with file metadata
     graphs: RwLock<HashMap<String, StoredIndex>>,
+    /// Workspaces (multi-repo indexes)
+    workspaces: RwLock<HashMap<String, WorkspaceInfo>>,
     running: RwLock<bool>,
     #[cfg(feature = "embeddings")]
     embedder: Option<Arc<EmbedderProvider>>,
@@ -228,15 +245,102 @@ impl IndexerService {
             config.max_concurrent_syncs,
         );
 
+        // Load persisted indexes from disk
+        let indexes = Self::load_indexes_from_disk(&config.indexes_path);
+        let workspaces = Self::load_workspaces_from_disk(&config.indexes_path);
+
+        if !indexes.is_empty() {
+            info!("Loaded {} persisted indexes from disk", indexes.len());
+        }
+        if !workspaces.is_empty() {
+            info!("Loaded {} persisted workspaces from disk", workspaces.len());
+        }
+
         Self {
             config,
             repo_manager,
-            indexes: RwLock::new(HashMap::new()),
+            indexes: RwLock::new(indexes),
             graphs: RwLock::new(HashMap::new()),
+            workspaces: RwLock::new(workspaces),
             running: RwLock::new(false),
             #[cfg(feature = "embeddings")]
             embedder: None,
         }
+    }
+
+    /// Load indexes from disk by scanning for metadata.json files
+    fn load_indexes_from_disk(indexes_path: &Path) -> HashMap<String, IndexInfo> {
+        let mut indexes = HashMap::new();
+
+        // Walk through the indexes directory looking for metadata.json files
+        if let Ok(entries) = std::fs::read_dir(indexes_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    // Recursively search provider directories (e.g., github/)
+                    Self::scan_provider_dir(&path, &mut indexes);
+                }
+            }
+        }
+
+        indexes
+    }
+
+    /// Scan a provider directory for index metadata
+    fn scan_provider_dir(provider_path: &Path, indexes: &mut HashMap<String, IndexInfo>) {
+        if let Ok(entries) = std::fs::read_dir(provider_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    // This could be owner/ directory
+                    Self::scan_owner_dir(&path, indexes);
+                }
+            }
+        }
+    }
+
+    /// Scan an owner directory for index metadata
+    fn scan_owner_dir(owner_path: &Path, indexes: &mut HashMap<String, IndexInfo>) {
+        if let Ok(entries) = std::fs::read_dir(owner_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    // This could be repo/ directory - check for metadata.json
+                    let metadata_path = path.join("metadata.json");
+                    if metadata_path.exists() {
+                        if let Ok(content) = std::fs::read_to_string(&metadata_path) {
+                            if let Ok(info) = serde_json::from_str::<IndexInfo>(&content) {
+                                indexes.insert(info.name.clone(), info);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Load workspaces from disk
+    fn load_workspaces_from_disk(indexes_path: &Path) -> HashMap<String, WorkspaceInfo> {
+        let mut workspaces = HashMap::new();
+        let workspaces_dir = indexes_path.join("workspaces");
+
+        if let Ok(entries) = std::fs::read_dir(&workspaces_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let workspace_file = path.join("workspace.json");
+                    if workspace_file.exists() {
+                        if let Ok(content) = std::fs::read_to_string(&workspace_file) {
+                            if let Ok(workspace) = serde_json::from_str::<WorkspaceInfo>(&content) {
+                                workspaces.insert(workspace.name.clone(), workspace);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        workspaces
     }
 
     /// Initialize the embedding model asynchronously.
@@ -487,9 +591,14 @@ impl IndexerService {
             graphs.insert(info.name.clone(), stored);
         }
 
-        // Store index info
-        let mut indexes = self.indexes.write().await;
-        indexes.insert(info.name.clone(), info.clone());
+        // Store index info in memory
+        {
+            let mut indexes = self.indexes.write().await;
+            indexes.insert(info.name.clone(), info.clone());
+        }
+
+        // Persist index metadata to disk
+        self.save_index_metadata(&info).await?;
 
         info!("Indexed {}: {} files", repo.id(), file_count);
         Ok(info)
@@ -761,6 +870,165 @@ impl IndexerService {
         }
 
         info!("Successfully deleted index: {}", name);
+        Ok(())
+    }
+
+    /// Save index metadata to disk
+    pub async fn save_index_metadata(&self, info: &IndexInfo) -> Result<()> {
+        // Create the index directory structure
+        let index_dir = if let Some(parent) = info.path.parent() {
+            parent.to_path_buf()
+        } else {
+            // Fall back to constructing path from index name
+            let parts: Vec<&str> = info.name.split('/').collect();
+            if parts.len() >= 3 {
+                self.config
+                    .indexes_path
+                    .join(parts[0])
+                    .join(parts[1])
+                    .join(parts[2])
+            } else {
+                self.config.indexes_path.join(&info.name)
+            }
+        };
+
+        std::fs::create_dir_all(&index_dir)?;
+
+        let metadata_path = index_dir.join("metadata.json");
+        let json = serde_json::to_string_pretty(info)
+            .map_err(|e| Error::IndexingFailed(format!("Failed to serialize metadata: {}", e)))?;
+        std::fs::write(&metadata_path, json)?;
+
+        info!("Saved index metadata to {:?}", metadata_path);
+        Ok(())
+    }
+
+    /// Create a workspace containing multiple repositories
+    pub async fn create_workspace(
+        &self,
+        name: &str,
+        repos: &[Repository],
+    ) -> Result<WorkspaceInfo> {
+        let workspace_dir = self.config.indexes_path.join("workspaces").join(name);
+        std::fs::create_dir_all(&workspace_dir)?;
+
+        let workspace = WorkspaceInfo {
+            name: name.to_string(),
+            path: workspace_dir.join("workspace.json"),
+            repositories: repos.to_vec(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        // Save workspace metadata to disk
+        let json = serde_json::to_string_pretty(&workspace)
+            .map_err(|e| Error::IndexingFailed(format!("Failed to serialize workspace: {}", e)))?;
+        std::fs::write(&workspace.path, &json)?;
+
+        // Add to in-memory map
+        {
+            let mut workspaces = self.workspaces.write().await;
+            workspaces.insert(name.to_string(), workspace.clone());
+        }
+
+        info!(
+            "Created workspace '{}' with {} repositories",
+            name,
+            repos.len()
+        );
+        Ok(workspace)
+    }
+
+    /// List all workspaces
+    pub async fn list_workspaces(&self) -> Vec<WorkspaceInfo> {
+        let workspaces = self.workspaces.read().await;
+        workspaces.values().cloned().collect()
+    }
+
+    /// Get a specific workspace
+    pub async fn get_workspace(&self, name: &str) -> Option<WorkspaceInfo> {
+        let workspaces = self.workspaces.read().await;
+        workspaces.get(name).cloned()
+    }
+
+    /// Get index names for all repositories in a workspace
+    pub async fn get_workspace_index_names(&self, name: &str) -> Option<Vec<String>> {
+        let workspaces = self.workspaces.read().await;
+        workspaces.get(name).map(|ws| {
+            ws.repositories
+                .iter()
+                .map(|repo| format!("{}/{}", repo.provider, repo.full_name))
+                .collect()
+        })
+    }
+
+    /// Add a repository to an existing workspace
+    pub async fn add_repo_to_workspace(&self, name: &str, repo: &Repository) -> Result<()> {
+        let mut workspaces = self.workspaces.write().await;
+        let workspace = workspaces
+            .get_mut(name)
+            .ok_or_else(|| Error::workspace_not_found(name))?;
+
+        workspace.repositories.push(repo.clone());
+        workspace.updated_at = Utc::now();
+
+        // Persist to disk
+        let json = serde_json::to_string_pretty(&*workspace)
+            .map_err(|e| Error::IndexingFailed(format!("Failed to serialize workspace: {}", e)))?;
+        std::fs::write(&workspace.path, &json)?;
+
+        info!(
+            "Added repository '{}' to workspace '{}'",
+            repo.id(),
+            name
+        );
+        Ok(())
+    }
+
+    /// Remove a repository from a workspace
+    pub async fn remove_repo_from_workspace(&self, name: &str, repo_id: &str) -> Result<()> {
+        let mut workspaces = self.workspaces.write().await;
+        let workspace = workspaces
+            .get_mut(name)
+            .ok_or_else(|| Error::workspace_not_found(name))?;
+
+        let original_len = workspace.repositories.len();
+        workspace.repositories.retain(|r| r.id() != repo_id);
+
+        if workspace.repositories.len() == original_len {
+            return Err(Error::repo_not_in_workspace(repo_id));
+        }
+
+        workspace.updated_at = Utc::now();
+
+        // Persist to disk
+        let json = serde_json::to_string_pretty(&*workspace)
+            .map_err(|e| Error::IndexingFailed(format!("Failed to serialize workspace: {}", e)))?;
+        std::fs::write(&workspace.path, &json)?;
+
+        info!(
+            "Removed repository '{}' from workspace '{}'",
+            repo_id,
+            name
+        );
+        Ok(())
+    }
+
+    /// Delete a workspace
+    pub async fn delete_workspace(&self, name: &str) -> Result<()> {
+        let mut workspaces = self.workspaces.write().await;
+
+        let workspace = workspaces
+            .remove(name)
+            .ok_or_else(|| Error::workspace_not_found(name))?;
+
+        // Remove workspace directory from disk
+        let workspace_dir = workspace.path.parent().unwrap_or(&workspace.path);
+        if workspace_dir.exists() {
+            std::fs::remove_dir_all(workspace_dir)?;
+        }
+
+        info!("Deleted workspace '{}'", name);
         Ok(())
     }
 
@@ -1963,5 +2231,515 @@ mod tests {
             let graphs = service.graphs.read().await;
             assert!(!graphs.contains_key(index_name));
         }
+    }
+
+    // =========================================================================
+    // Index Persistence Tests (TDD - these tests drive the implementation)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_new_service_loads_persisted_indexes() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        // Create index directories
+        let index_dir = config
+            .indexes_path
+            .join("github")
+            .join("owner")
+            .join("repo");
+        std::fs::create_dir_all(&index_dir).unwrap();
+
+        // Write index metadata to disk
+        let repo = crate::providers::Repository::new(
+            "github",
+            "owner",
+            "repo",
+            "https://github.com/owner/repo.git",
+        );
+        let info = IndexInfo {
+            name: "github/owner/repo".to_string(),
+            path: index_dir.join("index.leann"),
+            repository: repo,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            file_count: 42,
+            size_bytes: 1024,
+        };
+
+        // Save metadata file
+        let metadata_path = index_dir.join("metadata.json");
+        let json = serde_json::to_string_pretty(&info).unwrap();
+        std::fs::write(&metadata_path, json).unwrap();
+
+        // Create a NEW service - it should load the persisted index
+        let service = IndexerService::new(config, HashMap::new());
+        let indexes = service.list_indexes().await;
+
+        // This assertion will FAIL until we implement persistence loading
+        assert_eq!(indexes.len(), 1, "Expected 1 persisted index to be loaded");
+        assert_eq!(indexes[0].name, "github/owner/repo");
+        assert_eq!(indexes[0].file_count, 42);
+    }
+
+    #[tokio::test]
+    async fn test_save_index_persists_metadata_to_disk() {
+        // Test that save_index_metadata writes to disk correctly
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config.clone(), HashMap::new());
+
+        let repo = crate::providers::Repository::new(
+            "github",
+            "test",
+            "myrepo",
+            "https://github.com/test/myrepo.git",
+        );
+
+        let info = IndexInfo {
+            name: "github/test/myrepo".to_string(),
+            path: config
+                .indexes_path
+                .join("github")
+                .join("test")
+                .join("myrepo")
+                .join("index.leann"),
+            repository: repo,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            file_count: 100,
+            size_bytes: 2048,
+        };
+
+        // Call save_index_metadata (method we need to implement)
+        service.save_index_metadata(&info).await.unwrap();
+
+        // Verify metadata file exists
+        let metadata_path = config
+            .indexes_path
+            .join("github")
+            .join("test")
+            .join("myrepo")
+            .join("metadata.json");
+
+        assert!(
+            metadata_path.exists(),
+            "Index metadata should be persisted to disk"
+        );
+
+        // Verify metadata content
+        let content = std::fs::read_to_string(&metadata_path).unwrap();
+        let loaded: IndexInfo = serde_json::from_str(&content).unwrap();
+        assert_eq!(loaded.name, "github/test/myrepo");
+        assert_eq!(loaded.file_count, 100);
+    }
+
+    // =========================================================================
+    // Multi-repo Index Tests (TDD - these tests drive the implementation)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_create_workspace_index_with_multiple_repos() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config.clone(), HashMap::new());
+
+        // Create workspace with multiple repos
+        let repos = vec![
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "frontend",
+                "https://github.com/org/frontend.git",
+            ),
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "backend",
+                "https://github.com/org/backend.git",
+            ),
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "shared",
+                "https://github.com/org/shared.git",
+            ),
+        ];
+
+        // Create a workspace index that combines all repos
+        let workspace_name = "my-project";
+        service
+            .create_workspace(workspace_name, &repos)
+            .await
+            .unwrap();
+
+        // Verify workspace is listed
+        let workspaces = service.list_workspaces().await;
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].name, workspace_name);
+        assert_eq!(workspaces[0].repositories.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_workspace_persists_and_loads() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        // Create workspace with first service instance
+        {
+            let service = IndexerService::new(config.clone(), HashMap::new());
+
+            let repos = vec![
+                crate::providers::Repository::new(
+                    "github",
+                    "org",
+                    "repo1",
+                    "https://github.com/org/repo1.git",
+                ),
+                crate::providers::Repository::new(
+                    "github",
+                    "org",
+                    "repo2",
+                    "https://github.com/org/repo2.git",
+                ),
+            ];
+
+            service
+                .create_workspace("workspace1", &repos)
+                .await
+                .unwrap();
+        }
+
+        // Create NEW service - workspace should be loaded from disk
+        let service2 = IndexerService::new(config, HashMap::new());
+        let workspaces = service2.list_workspaces().await;
+
+        assert_eq!(
+            workspaces.len(),
+            1,
+            "Workspace should persist across service restarts"
+        );
+        assert_eq!(workspaces[0].name, "workspace1");
+        assert_eq!(workspaces[0].repositories.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_add_repo_to_workspace() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        // Create workspace with one repo
+        let repo1 = crate::providers::Repository::new(
+            "github",
+            "org",
+            "frontend",
+            "https://github.com/org/frontend.git",
+        );
+        service.create_workspace("my-project", &[repo1]).await.unwrap();
+
+        // Add another repo to the workspace
+        let repo2 = crate::providers::Repository::new(
+            "github",
+            "org",
+            "backend",
+            "https://github.com/org/backend.git",
+        );
+        service.add_repo_to_workspace("my-project", &repo2).await.unwrap();
+
+        // Verify workspace now has 2 repos
+        let workspaces = service.list_workspaces().await;
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].repositories.len(), 2);
+
+        let repo_names: Vec<_> = workspaces[0].repositories.iter().map(|r| r.name.as_str()).collect();
+        assert!(repo_names.contains(&"frontend"));
+        assert!(repo_names.contains(&"backend"));
+    }
+
+    #[tokio::test]
+    async fn test_add_repo_to_workspace_persists() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        // Create workspace and add repo
+        {
+            let service = IndexerService::new(config.clone(), HashMap::new());
+
+            let repo1 = crate::providers::Repository::new(
+                "github",
+                "org",
+                "repo1",
+                "https://github.com/org/repo1.git",
+            );
+            service.create_workspace("test-ws", &[repo1]).await.unwrap();
+
+            let repo2 = crate::providers::Repository::new(
+                "github",
+                "org",
+                "repo2",
+                "https://github.com/org/repo2.git",
+            );
+            service.add_repo_to_workspace("test-ws", &repo2).await.unwrap();
+        }
+
+        // New service should see the added repo
+        let service2 = IndexerService::new(config, HashMap::new());
+        let workspaces = service2.list_workspaces().await;
+
+        assert_eq!(workspaces[0].repositories.len(), 2, "Added repo should persist");
+    }
+
+    #[tokio::test]
+    async fn test_add_repo_to_nonexistent_workspace_fails() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        let repo = crate::providers::Repository::new(
+            "github",
+            "org",
+            "repo",
+            "https://github.com/org/repo.git",
+        );
+
+        let result = service.add_repo_to_workspace("nonexistent", &repo).await;
+        assert!(result.is_err(), "Should fail for nonexistent workspace");
+    }
+
+    #[tokio::test]
+    async fn test_remove_repo_from_workspace() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        // Create workspace with two repos
+        let repos = vec![
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "frontend",
+                "https://github.com/org/frontend.git",
+            ),
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "backend",
+                "https://github.com/org/backend.git",
+            ),
+        ];
+        service.create_workspace("my-project", &repos).await.unwrap();
+
+        // Remove one repo (repo.id() returns owner/name format)
+        service.remove_repo_from_workspace("my-project", "org/backend").await.unwrap();
+
+        // Verify workspace now has 1 repo
+        let workspaces = service.list_workspaces().await;
+        assert_eq!(workspaces[0].repositories.len(), 1);
+        assert_eq!(workspaces[0].repositories[0].name, "frontend");
+    }
+
+    #[tokio::test]
+    async fn test_remove_repo_from_workspace_persists() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        // Create workspace with 2 repos, then remove one
+        {
+            let service = IndexerService::new(config.clone(), HashMap::new());
+
+            let repos = vec![
+                crate::providers::Repository::new(
+                    "github",
+                    "org",
+                    "repo1",
+                    "https://github.com/org/repo1.git",
+                ),
+                crate::providers::Repository::new(
+                    "github",
+                    "org",
+                    "repo2",
+                    "https://github.com/org/repo2.git",
+                ),
+            ];
+            service.create_workspace("test-ws", &repos).await.unwrap();
+            service.remove_repo_from_workspace("test-ws", "org/repo2").await.unwrap();
+        }
+
+        // New service should see the removal
+        let service2 = IndexerService::new(config, HashMap::new());
+        let workspaces = service2.list_workspaces().await;
+
+        assert_eq!(workspaces[0].repositories.len(), 1, "Removal should persist");
+        assert_eq!(workspaces[0].repositories[0].name, "repo1");
+    }
+
+    #[tokio::test]
+    async fn test_remove_nonexistent_repo_from_workspace_fails() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        let repo = crate::providers::Repository::new(
+            "github",
+            "org",
+            "repo1",
+            "https://github.com/org/repo1.git",
+        );
+        service.create_workspace("test-ws", &[repo]).await.unwrap();
+
+        let result = service.remove_repo_from_workspace("test-ws", "org/nonexistent").await;
+        assert!(result.is_err(), "Should fail for nonexistent repo");
+    }
+
+    #[tokio::test]
+    async fn test_delete_workspace() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config.clone(), HashMap::new());
+
+        // Create workspace
+        let repo = crate::providers::Repository::new(
+            "github",
+            "org",
+            "repo",
+            "https://github.com/org/repo.git",
+        );
+        service.create_workspace("to-delete", &[repo]).await.unwrap();
+
+        // Verify it exists
+        assert_eq!(service.list_workspaces().await.len(), 1);
+
+        // Delete it
+        service.delete_workspace("to-delete").await.unwrap();
+
+        // Verify it's gone
+        assert_eq!(service.list_workspaces().await.len(), 0);
+
+        // New service should also not see it
+        let service2 = IndexerService::new(config, HashMap::new());
+        assert_eq!(service2.list_workspaces().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_workspace() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        // Create workspace
+        let repo = crate::providers::Repository::new(
+            "github",
+            "org",
+            "repo",
+            "https://github.com/org/repo.git",
+        );
+        service.create_workspace("test-ws", &[repo]).await.unwrap();
+
+        // Get workspace should succeed
+        let ws = service.get_workspace("test-ws").await;
+        assert!(ws.is_some());
+        assert_eq!(ws.unwrap().name, "test-ws");
+
+        // Get nonexistent workspace should return None
+        let ws = service.get_workspace("nonexistent").await;
+        assert!(ws.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_workspace_index_names() {
+        let dir = tempdir().unwrap();
+        let config = IndexerConfig {
+            repos_path: dir.path().join("repos"),
+            indexes_path: dir.path().join("indexes"),
+            ..Default::default()
+        };
+
+        let service = IndexerService::new(config, HashMap::new());
+
+        // Create workspace with two repos
+        let repos = vec![
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "frontend",
+                "https://github.com/org/frontend.git",
+            ),
+            crate::providers::Repository::new(
+                "github",
+                "org",
+                "backend",
+                "https://github.com/org/backend.git",
+            ),
+        ];
+        service.create_workspace("my-project", &repos).await.unwrap();
+
+        // Get index names for workspace
+        let names = service.get_workspace_index_names("my-project").await;
+        assert!(names.is_some());
+        let names = names.unwrap();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"github/org/frontend".to_string()));
+        assert!(names.contains(&"github/org/backend".to_string()));
+
+        // Nonexistent workspace should return None
+        let names = service.get_workspace_index_names("nonexistent").await;
+        assert!(names.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,11 @@ async fn main() -> anyhow::Result<()> {
             WorkspaceAction::Delete { name, force } => {
                 commands::workspace_delete(&config, &name, force).await?;
             }
-            WorkspaceAction::AddRepo { workspace, repo, token } => {
+            WorkspaceAction::AddRepo {
+                workspace,
+                repo,
+                token,
+            } => {
                 commands::workspace_add_repo(&config, &workspace, &repo, token.as_deref()).await?;
             }
             WorkspaceAction::RemoveRepo { workspace, repo_id } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ enum Commands {
         #[arg(short, long)]
         index: Vec<String>,
 
+        /// Search within a workspace (searches all repos in the workspace)
+        #[arg(short, long)]
+        workspace: Option<String>,
+
         /// Number of results to return
         #[arg(short = 'k', long, default_value = "10")]
         top_k: usize,
@@ -86,6 +90,12 @@ enum Commands {
     Config {
         #[command(subcommand)]
         action: ConfigAction,
+    },
+
+    /// Workspace management (multi-repo grouping)
+    Workspace {
+        #[command(subcommand)]
+        action: WorkspaceAction,
     },
 
     /// Start the MCP server (stdio transport)
@@ -111,6 +121,59 @@ enum ConfigAction {
         /// Output path for the configuration file
         #[arg(short, long)]
         output: Option<PathBuf>,
+    },
+}
+
+/// Workspace subcommands
+#[derive(Subcommand)]
+enum WorkspaceAction {
+    /// Create a new workspace
+    Create {
+        /// Workspace name
+        name: String,
+
+        /// Repository URLs to include
+        #[arg(required = true)]
+        repos: Vec<String>,
+
+        /// Git provider token
+        #[arg(long, env = "ISLANDS_GIT_TOKEN")]
+        token: Option<String>,
+    },
+
+    /// List all workspaces
+    List,
+
+    /// Delete a workspace
+    Delete {
+        /// Workspace name
+        name: String,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Add a repository to a workspace
+    AddRepo {
+        /// Workspace name
+        workspace: String,
+
+        /// Repository URL
+        repo: String,
+
+        /// Git provider token
+        #[arg(long, env = "ISLANDS_GIT_TOKEN")]
+        token: Option<String>,
+    },
+
+    /// Remove a repository from a workspace
+    RemoveRepo {
+        /// Workspace name
+        workspace: String,
+
+        /// Repository ID (owner/name format)
+        repo_id: String,
     },
 }
 
@@ -150,10 +213,11 @@ async fn main() -> anyhow::Result<()> {
         Commands::Search {
             query,
             index,
+            workspace,
             top_k,
         } => {
             let indexes = if index.is_empty() { None } else { Some(index) };
-            commands::search(&config, &query, indexes, top_k).await?;
+            commands::search(&config, &query, indexes, workspace.as_deref(), top_k).await?;
         }
         Commands::List => {
             commands::list_indexes(&config).await?;
@@ -167,6 +231,23 @@ async fn main() -> anyhow::Result<()> {
             }
             ConfigAction::Init { output } => {
                 commands::config_init(output).await?;
+            }
+        },
+        Commands::Workspace { action } => match action {
+            WorkspaceAction::Create { name, repos, token } => {
+                commands::workspace_create(&config, &name, &repos, token.as_deref()).await?;
+            }
+            WorkspaceAction::List => {
+                commands::workspace_list(&config).await?;
+            }
+            WorkspaceAction::Delete { name, force } => {
+                commands::workspace_delete(&config, &name, force).await?;
+            }
+            WorkspaceAction::AddRepo { workspace, repo, token } => {
+                commands::workspace_add_repo(&config, &workspace, &repo, token.as_deref()).await?;
+            }
+            WorkspaceAction::RemoveRepo { workspace, repo_id } => {
+                commands::workspace_remove_repo(&config, &workspace, &repo_id).await?;
             }
         },
         #[cfg(feature = "mcp")]


### PR DESCRIPTION
## Summary

Adds workspace management to Islands, enabling users to group multiple repositories together for organized searching and management. Workspaces persist across restarts and integrate with the search command.

## Changes Made

- **Service Layer**: Added `WorkspaceInfo` struct and workspace CRUD methods with disk persistence
- **Error Handling**: Added `WorkspaceNotFound` and `RepositoryNotInWorkspace` error variants
- **CLI Commands**: New `islands workspace` subcommand with create/list/delete/add-repo/remove-repo actions
- **Search Enhancement**: Added `--workspace` flag to scope searches to repositories in a workspace
- **Tests**: Comprehensive test coverage for all workspace operations (TDD approach)

## New CLI Commands

```bash
islands workspace create <name> <repos...> [--token]
islands workspace list
islands workspace delete <name> [--force]
islands workspace add-repo <workspace> <repo> [--token]
islands workspace remove-repo <workspace> <repo_id>
islands search --workspace <name> <query>
```

## Testing

- All 777 tests pass (1 pre-existing macOS case-sensitivity failure unrelated to these changes)
- Clippy passes with only pre-existing warning
- Followed TDD: wrote failing tests first, then implemented to pass

## Notes

- Workspace metadata stored in `indexes/workspaces/<name>/workspace.json`
- Repository IDs use `owner/name` format (e.g., `panbanda/islands`)
- Index names for workspace search use `provider/owner/name` format