### PR TITLE
fix: correct index path structure for metadata persistence

### DIFF
--- a/src/indexer/service.rs
+++ b/src/indexer/service.rs
@@ -450,7 +450,8 @@ impl IndexerService {
             .indexes_path
             .join(&repo.provider)
             .join(&repo.owner)
-            .join(format!("{}.leann", repo.name))
+            .join(&repo.name)
+            .join("index.leann")
     }
 
     /// Add and index a repository
@@ -570,7 +571,7 @@ impl IndexerService {
         let size_bytes = graph.len() as u64 * 4 * 384; // rough estimate: vectors * sizeof(f32) * dim
 
         let info = IndexInfo {
-            name: repo.id(),
+            name: format!("{}/{}", repo.provider, repo.full_name),
             path: index_path,
             repository: repo.clone(),
             created_at: Utc::now(),
@@ -1713,7 +1714,8 @@ mod tests {
         let path = service.index_path(&repo);
         assert!(path.to_string_lossy().contains("github"));
         assert!(path.to_string_lossy().contains("my-org"));
-        assert!(path.to_string_lossy().contains("my-repo.leann"));
+        assert!(path.to_string_lossy().contains("my-repo"));
+        assert!(path.to_string_lossy().contains("index.leann"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixed index path structure from `indexes/github/owner/repo.leann` (file) to `indexes/github/owner/repo/index.leann` (directory with file)
- Fixed `IndexInfo.name` to use `provider/owner/repo` format instead of just `owner/repo`

## Problem

When adding a repository with `islands add`, the index was saved successfully but `islands list` showed nothing. The root cause was that `save_index_metadata` used `path.parent()` on the index path, which returned the wrong directory:

- **Before**: `indexes/github/owner/repo.leann` -> parent = `indexes/github/owner/`
- **After**: `indexes/github/owner/repo/index.leann` -> parent = `indexes/github/owner/repo/`

The metadata was being saved to `indexes/github/owner/metadata.json` instead of `indexes/github/owner/repo/metadata.json`, so `load_persisted_indexes()` couldn't find it.

## Test plan

- [x] All existing tests pass (777 passed)
- [x] `test_index_path_structure` updated to verify new path format