### PR TITLE
feat: sync all indexes by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,10 +80,10 @@ enum Commands {
     /// List all indexed repositories
     List,
 
-    /// Sync and re-index a repository
+    /// Sync and re-index repositories (all if none specified)
     Sync {
-        /// Index name (provider/owner/repo)
-        index_name: String,
+        /// Index names to sync (syncs all if omitted)
+        index_names: Vec<String>,
     },
 
     /// Configuration management
@@ -222,8 +222,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::List => {
             commands::list_indexes(&config).await?;
         }
-        Commands::Sync { index_name } => {
-            commands::sync_repository(&config, &index_name).await?;
+        Commands::Sync { index_names } => {
+            commands::sync_repositories(&config, &index_names).await?;
         }
         Commands::Config { action } => match action {
             ConfigAction::Show => {


### PR DESCRIPTION
## Summary

- `islands sync` now syncs all indexes when no arguments provided
- Specific indexes can still be synced by passing names as arguments
- Shows progress indicator when syncing multiple indexes

## Usage

```bash
islands sync                           # sync all indexes
islands sync github/owner/repo         # sync specific index
islands sync repo1 repo2               # sync multiple indexes
```

## Test plan

- [ ] Run `islands sync` with multiple indexes and verify all are synced
- [ ] Run `islands sync <name>` and verify only that index is synced
- [ ] Run `islands sync nonexistent` and verify error is returned